### PR TITLE
Fix ModelData not applying to QuickItems

### DIFF
--- a/src/main/java/ca/tweetzy/flight/utils/QuickItem.java
+++ b/src/main/java/ca/tweetzy/flight/utils/QuickItem.java
@@ -321,10 +321,6 @@ public final class QuickItem {
         if (this.amount != -1)
             compiledItem.setAmount(this.amount);
 
-        // Apply Bukkit metadata
-        compiledItem.setItemMeta(compiledMeta);
-
-
         //
         // From now on we have to re-set the item
         //
@@ -334,6 +330,9 @@ public final class QuickItem {
                 compiledMeta.setCustomModelData(this.modelData);
             } catch (final Throwable t) {
             }
+
+        // Apply Bukkit metadata
+        compiledItem.setItemMeta(compiledMeta);
 
         for (final Map.Entry<String, String> entry : this.tags.entrySet()) {
             NBT.modify(compiledItem, nbt -> {


### PR DESCRIPTION
As the title says, currently modeldata for items doesn't work in any flight plugin because the modeldata is applied to the itemmeta before the modeldata is added to it.